### PR TITLE
Use reports endpoint and simplify report history

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,3 @@
+VITE_API_BASE_URL=http://localhost:8000
+VITE_GOOGLE_MAPS_API_KEY=your_api_key_here
+VITE_DEMO_MODE=false

--- a/frontend/src/pages/ReportHistory/ReportHistory.jsx
+++ b/frontend/src/pages/ReportHistory/ReportHistory.jsx
@@ -49,8 +49,8 @@ const ReportHistory = () => {
       try {
         setLoading(true);
         const response = await reportAPI.getUserReports();
-        setReports(response.data.reports || []);
-        setFilteredReports(response.data.reports || []);
+        setReports(response.data || []);
+        setFilteredReports(response.data || []);
       } catch (error) {
         toast.error("Failed to load reports");
         console.error("Error fetching reports:", error);

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -304,8 +304,7 @@ export const reportAPI = {
       return { data: { reports: demoUserReports } };
     }
 
-    const params = new URLSearchParams(filters);
-    return await api.get(`/api/reports/user?${params}`);
+    return await api.get('/api/reports', { params: filters });
   },
 
   // Get report details


### PR DESCRIPTION
## Summary
- Fetch reports from `/api/reports` with optional filters
- Read report list from `response.data` in report history
- Provide `.env.example` with `VITE_DEMO_MODE=false`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 27 errors, 3 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68abf955a2a88321aabc0029e442aead